### PR TITLE
Added ability to change button colors via Core Graphics.

### DIFF
--- a/SIAlertView/SIAlertItem.h
+++ b/SIAlertView/SIAlertItem.h
@@ -1,0 +1,33 @@
+//
+//  SIAlertItem.h
+//  SIAlertView
+//
+//
+//  Created by Kevin Cao on 5/30/13.
+//  Core Graphics integration by Christopher Constable.
+//  Copyright (c) 2013年 Sumi Interactive. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class SIAlertView;
+
+typedef NS_ENUM(NSInteger, SIAlertViewButtonType) {
+    SIAlertViewButtonTypeDefault = 0,
+    SIAlertViewButtonTypeDestructive,
+    SIAlertViewButtonTypeCancel
+};
+
+typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
+
+@interface SIAlertItem : NSObject
+
+@property (nonatomic, copy) NSString *title;
+@property (nonatomic, strong) UIColor *buttonColor;
+@property (nonatomic, assign) SIAlertViewButtonType type;
+@property (nonatomic, copy) SIAlertViewHandler action;
+
+- (UIImage *)imageForButton;
+- (UIImage *)imageForButtonHighlighted;
+
+@end

--- a/SIAlertView/SIAlertItem.m
+++ b/SIAlertView/SIAlertItem.m
@@ -1,0 +1,99 @@
+//
+//  SIAlertItem.m
+//  SIAlertView
+//
+//
+//  Created by Kevin Cao on 5/30/13.
+//  Core Graphics integration by Christopher Constable.
+//  Copyright (c) 2013年 Sumi Interactive. All rights reserved.
+//
+
+#import "SIAlertItem.h"
+
+@interface SIAlertItem ()
+
+@end
+
+@implementation UIColor (LightAndDark)
+
+- (UIColor *)lighterColor
+{
+    float h, s, b, a;
+    if ([self getHue:&h saturation:&s brightness:&b alpha:&a])
+        return [UIColor colorWithHue:h
+                          saturation:s
+                          brightness:MIN(b * 1.1, 1.0)
+                               alpha:a];
+    return nil;
+}
+
+- (UIColor *)darkerColor
+{
+    float h, s, b, a;
+    if ([self getHue:&h saturation:&s brightness:&b alpha:&a])
+        return [UIColor colorWithHue:h
+                          saturation:s
+                          brightness:b * 0.9
+                               alpha:a];
+    return nil;
+}
+
+@end
+
+@implementation SIAlertItem
+
+- (UIImage *)imageForButton
+{
+    CGSize buttonSize = CGSizeMake(9, 9);
+    UIGraphicsBeginImageContext(buttonSize);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    //// Color Declarations
+    UIColor* color = [self.buttonColor darkerColor];
+    UIColor* color2 = self.buttonColor;
+    
+    //// Rounded Rectangle Drawing
+    UIBezierPath* roundedRectanglePath = [UIBezierPath bezierPathWithRoundedRect: CGRectMake(0, 0, 9, 9) cornerRadius: 5];
+    [color2 setFill];
+    [roundedRectanglePath fill];
+    [color setStroke];
+    roundedRectanglePath.lineWidth = 1;
+    [roundedRectanglePath stroke];
+
+    CGImageRef imgRef = CGBitmapContextCreateImage(context);
+    UIImage* image = [UIImage imageWithCGImage:imgRef];
+    CGImageRelease(imgRef);
+    
+    UIGraphicsEndImageContext();
+    
+    return image;
+}
+
+- (UIImage *)imageForButtonHighlighted
+{
+    CGSize buttonSize = CGSizeMake(9, 9);
+    UIGraphicsBeginImageContext(buttonSize);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    //// Color Declarations
+    UIColor* color = [[self.buttonColor darkerColor] darkerColor];
+    UIColor* color2 = [self.buttonColor darkerColor];
+    
+    //// Rounded Rectangle Drawing
+    UIBezierPath* roundedRectanglePath = [UIBezierPath bezierPathWithRoundedRect: CGRectMake(0, 0, 9, 9) cornerRadius: 5];
+    [color2 setFill];
+    [roundedRectanglePath fill];
+    [color setStroke];
+    roundedRectanglePath.lineWidth = 1;
+    [roundedRectanglePath stroke];
+    
+    CGImageRef imgRef = CGBitmapContextCreateImage(context);
+    UIImage* image = [UIImage imageWithCGImage:imgRef];
+    CGImageRelease(imgRef);
+    
+    UIGraphicsEndImageContext();
+    
+    return image;
+}
+
+@end

--- a/SIAlertView/SIAlertView.h
+++ b/SIAlertView/SIAlertView.h
@@ -34,7 +34,7 @@ typedef NS_ENUM(NSInteger, SIAlertViewTransitionStyle) {
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) NSString *message;
 
-/** For button drawing. To preserve backwards compatibility. Defaults to 1 (YES). */
+/** For button drawing. To preserve backwards compatibility, this defaults to 0 (NO). */
 @property (nonatomic) NSInteger useCoreGraphics NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
 
 @property (nonatomic, assign) SIAlertViewTransitionStyle transitionStyle; // default is SIAlertViewTransitionStyleSlideFromBottom

--- a/SIAlertView/SIAlertView.h
+++ b/SIAlertView/SIAlertView.h
@@ -7,17 +7,12 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "SIAlertItem.h"
 
 extern NSString *const SIAlertViewWillShowNotification;
 extern NSString *const SIAlertViewDidShowNotification;
 extern NSString *const SIAlertViewWillDismissNotification;
 extern NSString *const SIAlertViewDidDismissNotification;
-
-typedef NS_ENUM(NSInteger, SIAlertViewButtonType) {
-    SIAlertViewButtonTypeDefault = 0,
-    SIAlertViewButtonTypeDestructive,
-    SIAlertViewButtonTypeCancel
-};
 
 typedef NS_ENUM(NSInteger, SIAlertViewBackgroundStyle) {
     SIAlertViewBackgroundStyleGradient = 0,
@@ -33,12 +28,14 @@ typedef NS_ENUM(NSInteger, SIAlertViewTransitionStyle) {
 };
 
 @class SIAlertView;
-typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
 
 @interface SIAlertView : UIView
 
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) NSString *message;
+
+/** For button drawing. To preserve backwards compatibility. Defaults to 1 (YES). */
+@property (nonatomic) NSInteger useCoreGraphics NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
 
 @property (nonatomic, assign) SIAlertViewTransitionStyle transitionStyle; // default is SIAlertViewTransitionStyleSlideFromBottom
 @property (nonatomic, assign) SIAlertViewBackgroundStyle backgroundStyle; // default is SIAlertViewButtonTypeGradient
@@ -54,6 +51,12 @@ typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
 @property (nonatomic, strong) UIColor *messageColor NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIFont *titleFont NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIFont *messageFont NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIColor *defaultButtonFontColor NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIColor *defaultButtonColor NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIColor *destructiveButtonFontColor NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIColor *destructiveButtonColor NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIColor *cancelButtonFontColor NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIColor *cancelButtonColor NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIFont *buttonFont NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
 @property (nonatomic, assign) CGFloat cornerRadius NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR; // default is 2.0
 @property (nonatomic, assign) CGFloat shadowRadius NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR; // default is 8.0

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -84,6 +84,7 @@ static SIAlertView *__si_alert_current_view;
         self.opaque = NO;
         self.windowLevel = UIWindowLevelAlert;
     }
+    
     return self;
 }
 
@@ -114,20 +115,6 @@ static SIAlertView *__si_alert_current_view;
         }
     }
 }
-
-@end
-
-#pragma mark - SIAlertItem
-
-@interface SIAlertItem : NSObject
-
-@property (nonatomic, copy) NSString *title;
-@property (nonatomic, assign) SIAlertViewButtonType type;
-@property (nonatomic, copy) SIAlertViewHandler action;
-
-@end
-
-@implementation SIAlertItem
 
 @end
 
@@ -176,6 +163,13 @@ static SIAlertView *__si_alert_current_view;
     appearance.messageColor = [UIColor darkGrayColor];
     appearance.titleFont = [UIFont boldSystemFontOfSize:20];
     appearance.messageFont = [UIFont systemFontOfSize:16];
+    appearance.useCoreGraphics = 0;
+    appearance.defaultButtonFontColor = [UIColor darkGrayColor];
+    appearance.defaultButtonColor = [UIColor colorWithRed:231.0 / 255.0 green:231.0 / 255.0 blue:231.0 / 255.0 alpha:1.0];
+    appearance.destructiveButtonFontColor = [UIColor whiteColor];
+    appearance.destructiveButtonColor = [UIColor colorWithRed:240.0 / 255.0 green:70.0 / 255.0 blue:62.0 / 255.0 alpha:1.0];
+    appearance.cancelButtonFontColor = [UIColor darkGrayColor];
+    appearance.cancelButtonColor = [UIColor colorWithRed:205.0 / 255.0 green:205.0 / 255.0 blue:205.0 / 255.0 alpha:1.0];
     appearance.buttonFont = [UIFont systemFontOfSize:[UIFont buttonFontSize]];
     appearance.cornerRadius = 2;
     appearance.shadowRadius = 8;
@@ -193,7 +187,19 @@ static SIAlertView *__si_alert_current_view;
 		_title = title;
         _message = message;
 		self.items = [[NSMutableArray alloc] init];
+        
+        // Set the default button colors.
+         SIAlertView *appearance = [SIAlertView appearance];
+        _defaultButtonFontColor = appearance.defaultButtonFontColor;
+        _defaultButtonColor = appearance.defaultButtonColor;
+        _destructiveButtonFontColor = appearance.destructiveButtonFontColor;
+        _destructiveButtonColor = appearance.destructiveButtonColor;
+        _cancelButtonFontColor = appearance.cancelButtonFontColor;
+        _cancelButtonColor = appearance.cancelButtonColor;
+        
+        _useCoreGraphics = appearance.useCoreGraphics;
 	}
+    
 	return self;
 }
 
@@ -809,22 +815,61 @@ static SIAlertView *__si_alert_current_view;
 {
     self.buttons = [[NSMutableArray alloc] initWithCapacity:self.items.count];
     for (NSUInteger i = 0; i < self.items.count; i++) {
-        UIButton *button = [self buttonForItemIndex:i];
+        UIButton *button;
+        if (self.useCoreGraphics) {
+            button = [self buttonForCoreGraphicsItemIndex:i];
+        }
+        else {
+            button = [self buttonForItemIndex:i];
+        }
         [self.buttons addObject:button];
         [self.containerView addSubview:button];
     }
+}
+
+- (UIButton *)buttonForCoreGraphicsItemIndex:(NSUInteger)index
+{
+    SIAlertItem *item = self.items[index];
+    
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
+    button.titleLabel.font = self.buttonFont;
+    
+    // Set button colors
+    switch (item.type) {
+		case SIAlertViewButtonTypeCancel:
+            item.buttonColor = self.cancelButtonColor;
+            [button setTitleColor:self.cancelButtonFontColor forState:UIControlStateNormal];
+            [button setTitleColor:self.cancelButtonFontColor forState:UIControlStateHighlighted];
+            break;
+		case SIAlertViewButtonTypeDestructive:
+            item.buttonColor = self.destructiveButtonColor;
+            [button setTitleColor:self.destructiveButtonFontColor forState:UIControlStateNormal];
+            [button setTitleColor:self.destructiveButtonFontColor forState:UIControlStateHighlighted];
+            break;
+		case SIAlertViewButtonTypeDefault:
+		default:
+            item.buttonColor = self.defaultButtonColor;
+            [button setTitleColor:self.defaultButtonFontColor forState:UIControlStateNormal];
+            [button setTitleColor:self.defaultButtonFontColor forState:UIControlStateHighlighted];
+			break;
+	}
+    
+    UIImage *normalImage = [item imageForButton];
+	UIImage *highlightedImage = [item imageForButtonHighlighted];
+        
+    return [self finishCreatingButton:button
+                              forItem:item
+                      withNormalImage:normalImage
+                  andHighlightedImage:highlightedImage];
 }
 
 - (UIButton *)buttonForItemIndex:(NSUInteger)index
 {
     SIAlertItem *item = self.items[index];
 	UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
-	button.tag = index;
-	button.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-    button.titleLabel.font = self.buttonFont;
-	[button setTitle:item.title forState:UIControlStateNormal];
 	UIImage *normalImage = nil;
 	UIImage *highlightedImage = nil;
+    
 	switch (item.type) {
 		case SIAlertViewButtonTypeCancel:
 			normalImage = [UIImage imageNamed:@"SIAlertView.bundle/button-cancel"];
@@ -846,6 +891,22 @@ static SIAlertView *__si_alert_current_view;
             [button setTitleColor:[UIColor colorWithWhite:0.4 alpha:0.8] forState:UIControlStateHighlighted];
 			break;
 	}
+    
+    return [self finishCreatingButton:button
+                              forItem:item
+                      withNormalImage:normalImage
+                  andHighlightedImage:highlightedImage];
+}
+
+- (UIButton *)finishCreatingButton:(UIButton *)button
+                           forItem:(SIAlertItem *)item
+                   withNormalImage:(UIImage *)normalImage
+               andHighlightedImage:(UIImage *)highlightedImage
+{
+    button.tag = [self.items indexOfObject:item];
+	button.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    button.titleLabel.font = self.buttonFont;
+	[button setTitle:item.title forState:UIControlStateNormal];
 	CGFloat hInset = floorf(normalImage.size.width / 2);
 	CGFloat vInset = floorf(normalImage.size.height / 2);
 	UIEdgeInsets insets = UIEdgeInsetsMake(vInset, hInset, vInset, hInset);
@@ -918,6 +979,55 @@ static SIAlertView *__si_alert_current_view;
     }
     _messageColor = messageColor;
     self.messageLabel.textColor = messageColor;
+}
+
+- (void)setDefaultButtonFontColor:(UIColor *)defaultButtonFontColor
+{
+    if (_defaultButtonFontColor == defaultButtonFontColor) {
+        return;
+    }
+    _defaultButtonFontColor = defaultButtonFontColor;
+}
+
+- (void)setDefaultButtonColor:(UIColor *)defaultButtonColor
+{
+    if (_defaultButtonColor == defaultButtonColor) {
+        return;
+    }
+    
+    _defaultButtonColor = defaultButtonColor;
+}
+
+-(void)setDestructiveButtonFontColor:(UIColor *)destructiveButtonFontColor
+{
+    if (_destructiveButtonFontColor == destructiveButtonFontColor) {
+        return;
+    }
+    _destructiveButtonFontColor = destructiveButtonFontColor;
+}
+
+- (void)setDestructiveButtonColor:(UIColor *)destructiveButtonColor
+{
+    if (_destructiveButtonColor == destructiveButtonColor) {
+        return;
+    }
+    _destructiveButtonColor = destructiveButtonColor;
+}
+
+- (void)setCancelButtonFontColor:(UIColor *)cancelButtonFontColor
+{
+    if (_cancelButtonFontColor == cancelButtonFontColor) {
+        return;
+    }
+    _cancelButtonFontColor = cancelButtonFontColor;
+}
+
+- (void)setCancelButtonColor:(UIColor *)cancelButtonColor
+{
+    if (_cancelButtonColor == cancelButtonColor) {
+        return;
+    }
+    _cancelButtonColor = cancelButtonColor;
 }
 
 - (void)setButtonFont:(UIFont *)buttonFont

--- a/SIAlertViewExample/SIAlertViewExample.xcodeproj/project.pbxproj
+++ b/SIAlertViewExample/SIAlertViewExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		74F6204117595DF500DB6DE6 /* SIAlertItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 74F6204017595DF500DB6DE6 /* SIAlertItem.m */; };
 		7E23C67317325EAA00784CF1 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E23C67217325EAA00784CF1 /* UIKit.framework */; };
 		7E23C67517325EAA00784CF1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E23C67417325EAA00784CF1 /* Foundation.framework */; };
 		7E23C67717325EAA00784CF1 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E23C67617325EAA00784CF1 /* CoreGraphics.framework */; };
@@ -29,6 +30,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		74F6203F17595DF500DB6DE6 /* SIAlertItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SIAlertItem.h; sourceTree = "<group>"; };
+		74F6204017595DF500DB6DE6 /* SIAlertItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SIAlertItem.m; sourceTree = "<group>"; };
 		7E23C66F17325EAA00784CF1 /* SIAlertViewExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SIAlertViewExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E23C67217325EAA00784CF1 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		7E23C67417325EAA00784CF1 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -129,6 +132,8 @@
 			isa = PBXGroup;
 			children = (
 				7E23C69917325EBD00784CF1 /* SIAlertView.bundle */,
+				74F6203F17595DF500DB6DE6 /* SIAlertItem.h */,
+				74F6204017595DF500DB6DE6 /* SIAlertItem.m */,
 				7E23C69A17325EBD00784CF1 /* SIAlertView.h */,
 				7E23C69B17325EBD00784CF1 /* SIAlertView.m */,
 			);
@@ -244,6 +249,7 @@
 				7E23C68317325EAA00784CF1 /* AppDelegate.m in Sources */,
 				7E23C69217325EAB00784CF1 /* ViewController.m in Sources */,
 				7E23C69D17325EBD00784CF1 /* SIAlertView.m in Sources */,
+				74F6204117595DF500DB6DE6 /* SIAlertItem.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -376,6 +382,7 @@
 				7E23C69717325EAB00784CF1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/SIAlertViewExample/SIAlertViewExample/ViewController.m
+++ b/SIAlertViewExample/SIAlertViewExample/ViewController.m
@@ -18,12 +18,23 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-	
+    
     [[SIAlertView appearance] setMessageFont:[UIFont systemFontOfSize:13]];
     [[SIAlertView appearance] setTitleColor:[UIColor greenColor]];
     [[SIAlertView appearance] setMessageColor:[UIColor purpleColor]];
     [[SIAlertView appearance] setCornerRadius:12];
     [[SIAlertView appearance] setShadowRadius:20];
+    
+    // If you want to use custom colors, you can set this appearance property to 1.
+    // To preserve backwards compatibility, this is set to 0 by default.
+    // The appearance properties below will not have any affect unless this is enabled.
+    //[[SIAlertView appearance] setUseCoreGraphics:1];
+    
+    [[SIAlertView appearance] setDefaultButtonColor:[UIColor colorWithRed:18.0f / 255.0f
+                                                                    green:138.0f / 255.0f
+                                                                     blue:177.0f / 255.0f
+                                                                    alpha:1.0]];
+    [[SIAlertView appearance] setDefaultButtonFontColor:[UIColor whiteColor]];
 }
 
 #pragma mark - Actions


### PR DESCRIPTION
#### This pull will not affect any apps currently using SIAlertView. It adds opt-in features.

That said, this is a relatively big change so don't feel obligated to merge it if you don't want to :)

I wanted to change some of the characteristics (color, shadow, etc) of the buttons but I noticed they were images. I tried to replicate them a closely and as I could using core graphics so the background, shadow, and virtually any other property can be easily changed.

By default, SIAlertView still uses the images. However, if you want to customize the buttons you can use UIAppearance like so:

``` obj-c
[[SIAlertView appearance] setUseCoreGraphics:1];
[[SIAlertView appearance] setDefaultButtonColor:[UIColor colorWithRed:18.0f / 255.0f
                                                                    green:138.0f / 255.0f
                                                                     blue:177.0f / 255.0f
                                                                    alpha:1.0]];
[[SIAlertView appearance] setDefaultButtonFontColor:[UIColor whiteColor]];
[[SIAlertView appearance] setDestructiveButtonColor:[UIColor superBrightRedColor]];

// etc...
```

Here's a sample:
![ios simulator screen shot may 31 2013 7 17 54 pm](https://f.cloud.github.com/assets/564781/593937/c04d9602-ca4b-11e2-92a7-e88ef5a6d024.png)

I've only exposed a few properties but I think moving to Core Graphics could make SIAlertView really powerful. I'd love to continue adding to it after this.

Let me know your thoughts / concerns!
