### PR TITLE
Orientation support for iOS 5

### DIFF
--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -163,6 +163,21 @@ static SIAlertView *__si_alert_current_view;
     [self.alertView invaliadateLayout];
 }
 
+- (NSUInteger)supportedInterfaceOrientations
+{
+    return UIInterfaceOrientationMaskAll;
+}
+
+- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation
+{
+    return YES;
+}
+
+- (BOOL)shouldAutorotate
+{
+    return YES;
+}
+
 @end
 
 #pragma mark - SIAlert

--- a/SIAlertViewExample/SIAlertViewExample/ViewController.m
+++ b/SIAlertViewExample/SIAlertViewExample/ViewController.m
@@ -203,4 +203,19 @@ id observer1,observer2,observer3,observer4;
     [self alert3:nil];
 }
 
+- (NSUInteger)supportedInterfaceOrientations
+{
+    return UIInterfaceOrientationMaskAll;
+}
+
+- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation
+{
+    return YES;
+}
+
+- (BOOL)shouldAutorotate
+{
+    return YES;
+}
+
 @end


### PR DESCRIPTION
The alert's window was not rotating in iOS 5. Added support for this by implementing the supported interface orientation methods in the windows root view controller.
