### PR TITLE
fixed issue that keyboard won't show up in iOS 5 after SIAlertView is dismissed

### DIFF
--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -39,6 +39,7 @@ static SIAlertView *__si_alert_current_view;
 @interface SIAlertView ()
 
 @property (nonatomic, strong) NSMutableArray *items;
+@property (nonatomic, strong) UIWindow *oldKeyWindow;
 @property (nonatomic, strong) UIWindow *alertWindow;
 @property (nonatomic, assign, getter = isVisible) BOOL visible;
 
@@ -304,6 +305,8 @@ static SIAlertView *__si_alert_current_view;
 
 - (void)show
 {
+    self.oldKeyWindow = [[UIApplication sharedApplication] keyWindow];
+
     if (![[SIAlertView sharedQueue] containsObject:self]) {
         [[SIAlertView sharedQueue] addObject:self];
     }
@@ -438,6 +441,8 @@ static SIAlertView *__si_alert_current_view;
             [SIAlertView hideBackgroundAnimated:YES];
         }
     }
+    
+    [self.oldKeyWindow makeKeyAndVisible];
 }
 
 #pragma mark - Transitions


### PR DESCRIPTION
to reproduce the issue, try to add a text field to the demo app. in ios 5, the `UIWindow` firstResponders (such as `UIKeyboard`) won't fire after `SLAlertView` was shown.
