### PR TITLE
add textfield support

### DIFF
--- a/SIAlertView/SIAlertView.h
+++ b/SIAlertView/SIAlertView.h
@@ -32,6 +32,11 @@ typedef NS_ENUM(NSInteger, SIAlertViewTransitionStyle) {
     SIAlertViewTransitionStyleDropDown
 };
 
+typedef NS_ENUM(NSInteger, SIAlertViewStyle) {
+    SIAlertViewStyleDefault = 0,
+    SIAlertViewStyleTextInput
+};
+
 @class SIAlertView;
 typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
 
@@ -39,7 +44,9 @@ typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
 
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) NSString *message;
+@property (nonatomic, copy, readonly) NSString *inputText;
 
+@property (nonatomic, assign) SIAlertViewStyle alertViewStyle; // default is SIAlertViewStyleDefault
 @property (nonatomic, assign) SIAlertViewTransitionStyle transitionStyle; // default is SIAlertViewTransitionStyleSlideFromBottom
 @property (nonatomic, assign) SIAlertViewBackgroundStyle backgroundStyle; // default is SIAlertViewButtonTypeGradient
 

--- a/SIAlertView/SIAlertView.h
+++ b/SIAlertView/SIAlertView.h
@@ -34,7 +34,7 @@ typedef NS_ENUM(NSInteger, SIAlertViewTransitionStyle) {
 
 typedef NS_ENUM(NSInteger, SIAlertViewStyle) {
     SIAlertViewStyleDefault = 0,
-    SIAlertViewStyleTextInput
+    SIAlertViewStylePlainTextInput
 };
 
 @class SIAlertView;

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -852,6 +852,7 @@ static SIAlertView *__si_alert_current_view;
     if(!self.textField) {
         self.textField = [[UITextField alloc] initWithFrame:self.bounds];
         self.textField.delegate = self;
+        self.textField.text = @"";
         self.textField.borderStyle = UITextBorderStyleBezel;
         [self.containerView addSubview:self.textField];
 #if DEBUG_LAYOUT

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -359,6 +359,8 @@ static SIAlertView *__si_alert_current_view;
         NSInteger index = [[SIAlertView sharedQueue] indexOfObject:self];
         if (index < [SIAlertView sharedQueue].count - 1) {
             [self dismissAnimated:YES cleanup:NO]; // dismiss to show next alert view
+        } else if(self.textField) {
+            [self.textField becomeFirstResponder];
         }
     }];
 }

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -780,7 +780,7 @@ static SIAlertView *__si_alert_current_view;
     [self setupContainerView];
     [self updateTitleLabel];
     [self updateMessageLabel];
-    if(self.alertViewStyle == SIAlertViewStyleTextInput) {
+    if(self.alertViewStyle == SIAlertViewStylePlainTextInput) {
         [self setupTextField];
     }
     [self setupButtons];
@@ -980,10 +980,10 @@ static SIAlertView *__si_alert_current_view;
 
     //calculate new position
     CGRect containerFrame = self.containerView.frame;
-    CGRect keyboardFrame = [self.containerView convertRect:keyboardEndFrame toView:nil];
+    CGRect convertedKeyboardFrame = [self convertRect:keyboardEndFrame fromView:self.window];
     CGFloat adjustedHeight = self.bounds.size.height;
     if(up) {
-        adjustedHeight -= keyboardFrame.size.height;
+        adjustedHeight -= convertedKeyboardFrame.size.height;
     }
     containerFrame.origin.y = (adjustedHeight - containerFrame.size.height) / 2;
     
@@ -993,9 +993,17 @@ static SIAlertView *__si_alert_current_view;
     self.containerView.frame = containerFrame;
     [UIView commitAnimations];
     
-    // Set keyboardOffset to the width of the keyboard.
-    // This property is used to adjust the alertView y position on willRotate, i.e. before the rotation occurs. Therefore the width is used instead of height.
-    self.keyboardOffset = up ? keyboardFrame.size.width : 0;
+    //keyboardOffset is used to adjust the alertView y position on willRotate, i.e. before the rotation occurs. Therefore the height is set dependent of the current orientation
+    if(up) {
+        self.keyboardOffset = UIInterfaceOrientationIsPortrait([[UIDevice currentDevice] orientation]) ? keyboardEndFrame.size.height : keyboardEndFrame.size.width;
+    } else {
+        self.keyboardOffset = 0;
+    }
+}
+
++ (CGRect) convertRect:(CGRect)rect toView:(UIView *)view {
+    UIWindow *window = [view isKindOfClass:[UIWindow class]] ? (UIWindow *) view : [view window];
+    return [view convertRect:[window convertRect:rect fromWindow:nil] fromView:nil];
 }
 
 #pragma mark - UIAppearance setters

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -1001,11 +1001,6 @@ static SIAlertView *__si_alert_current_view;
     }
 }
 
-+ (CGRect) convertRect:(CGRect)rect toView:(UIView *)view {
-    UIWindow *window = [view isKindOfClass:[UIWindow class]] ? (UIWindow *) view : [view window];
-    return [view convertRect:[window convertRect:rect fromWindow:nil] fromView:nil];
-}
-
 #pragma mark - UIAppearance setters
 
 - (void)setViewBackgroundColor:(UIColor *)viewBackgroundColor

--- a/SIAlertViewExample/SIAlertViewExample/ViewController.m
+++ b/SIAlertViewExample/SIAlertViewExample/ViewController.m
@@ -135,7 +135,7 @@ id observer1,observer2,observer3,observer4;
 - (IBAction)alert3:(id)sender
 {
     SIAlertView *alertView = [[SIAlertView alloc] initWithTitle:nil andMessage:@"Message3"];
-    alertView.alertViewStyle = SIAlertViewStyleTextInput;
+    alertView.alertViewStyle = SIAlertViewStylePlainTextInput;
     [alertView addButtonWithTitle:@"Cancel"
                              type:SIAlertViewButtonTypeCancel
                           handler:^(SIAlertView *alertView) {

--- a/SIAlertViewExample/SIAlertViewExample/ViewController.m
+++ b/SIAlertViewExample/SIAlertViewExample/ViewController.m
@@ -135,6 +135,7 @@ id observer1,observer2,observer3,observer4;
 - (IBAction)alert3:(id)sender
 {
     SIAlertView *alertView = [[SIAlertView alloc] initWithTitle:nil andMessage:@"Message3"];
+    alertView.alertViewStyle = SIAlertViewStyleTextInput;
     [alertView addButtonWithTitle:@"Cancel"
                              type:SIAlertViewButtonTypeCancel
                           handler:^(SIAlertView *alertView) {
@@ -144,6 +145,7 @@ id observer1,observer2,observer3,observer4;
                              type:SIAlertViewButtonTypeDefault
                           handler:^(SIAlertView *alertView) {
                               NSLog(@"OK Clicked");
+                              NSLog(@"Textinput: %@", alertView.inputText);
                           }];
     alertView.transitionStyle = SIAlertViewTransitionStyleDropDown;
     alertView.backgroundStyle = SIAlertViewBackgroundStyleSolid;


### PR DESCRIPTION
resolves #20 
resolves #24

Enable a textfield by setting:

``` objective-c
alertViewStyle = SIAlertViewStylePlainTextInput;
```

Retrieve the entered text in your callback with the `inputText` property

Needs some more work to be able to style the textfield, though UITextField seems to have no UIAppearance support. Maybe a solution would be to expose the textfield to make it configurable from outside?
