### PR TITLE
Adding a UIView contentView to the alert for generic usage

### DIFF
--- a/SIAlertView/SIAlertView.h
+++ b/SIAlertView/SIAlertView.h
@@ -39,6 +39,7 @@ typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
 
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) NSString *message;
+@property (nonatomic, strong) UIView *contentView;
 
 @property (nonatomic, assign) SIAlertViewTransitionStyle transitionStyle; // default is SIAlertViewTransitionStyleSlideFromBottom
 @property (nonatomic, assign) SIAlertViewBackgroundStyle backgroundStyle; // default is SIAlertViewButtonTypeGradient
@@ -49,6 +50,8 @@ typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
 @property (nonatomic, copy) SIAlertViewHandler didDismissHandler;
 
 @property (nonatomic, readonly, getter = isVisible) BOOL visible;
+
+@property (nonatomic, readonly, getter = isParallaxEffectEnabled) BOOL enabledParallaxEffect;
 
 @property (nonatomic, strong) UIColor *viewBackgroundColor NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIColor *titleColor NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
@@ -62,11 +65,8 @@ typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
 @property (nonatomic, assign) CGFloat cornerRadius NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR; // default is 2.0
 @property (nonatomic, assign) CGFloat shadowRadius NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR; // default is 8.0
 
-- (void)setDefaultButtonImage:(UIImage *)defaultButtonImage forState:(UIControlState)state NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
-- (void)setCancelButtonImage:(UIImage *)cancelButtonImage forState:(UIControlState)state NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
-- (void)setDestructiveButtonImage:(UIImage *)destructiveButtonImage forState:(UIControlState)state NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
-
 - (id)initWithTitle:(NSString *)title andMessage:(NSString *)message;
+- (id)initWithTitle:(NSString *)title andMessage:(NSString *)message andContentView:(UIView *)contentView;
 - (void)addButtonWithTitle:(NSString *)title type:(SIAlertViewButtonType)type handler:(SIAlertViewHandler)handler;
 
 - (void)show;


### PR DESCRIPTION
- Adding a generic UIView on the alert to supply the feature removed from early versions iOS 7 betas. (can be used as UIImageViews, TableViews, or any other UIView subclass)
- Added the parallax effect commited by @Fr4ncis with some little tweeks
- Removal of some warnings due API's deprecation
- Code is iOS 7 only

Usage: Just set the property -contentView: or alloc/init with the designated initializer and you're good to go.

Usage example:

![img_6248](https://f.cloud.github.com/assets/2243183/1070280/2e6aabfa-144a-11e3-8eb2-6eecc966fc86.PNG)
