### PR TITLE
add  messageMinLineCount and messageMaxLine configuration via appearance

### DIFF
--- a/SIAlertView.podspec
+++ b/SIAlertView.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name     = 'SIAlertView'
-  s.version  = '1.3'
+  s.version  = '1.31'
   s.platform = :ios, '5.0'
   s.license  = 'MIT'
   s.summary  = 'An UIAlertView replacement.'
-  s.homepage = 'https://github.com/Sumi-Interactive/SIAlertView'
+  s.homepage = 'https://github.com/qiaoxueshi/SIAlertView'
   s.author   = { 'Sumi Interactive' => 'developer@sumi-sumi.com' }
-  s.source   = { :git => 'https://github.com/Sumi-Interactive/SIAlertView.git',
-                 :tag => '1.3' }
+  s.source   = { :git => 'https://github.com/qiaoxueshi/SIAlertView.git',
+                 :tag => 'Joey1.31' }
 
   s.description = 'An UIAlertView replacement with block syntax and fancy transition styles.'
 

--- a/SIAlertView.podspec
+++ b/SIAlertView.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/qiaoxueshi/SIAlertView'
   s.author   = { 'Sumi Interactive' => 'developer@sumi-sumi.com' }
   s.source   = { :git => 'https://github.com/qiaoxueshi/SIAlertView.git',
-                 :tag => '1.32' }
+                 :tag => '1.33' }
 
   s.description = 'An UIAlertView replacement with block syntax and fancy transition styles.'
 

--- a/SIAlertView.podspec
+++ b/SIAlertView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'SIAlertView'
-  s.version  = '1.32'
+  s.version  = '1.33'
   s.platform = :ios, '5.0'
   s.license  = 'MIT'
   s.summary  = 'An UIAlertView replacement.'

--- a/SIAlertView.podspec
+++ b/SIAlertView.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name     = 'SIAlertView'
-  s.version  = '1.31'
+  s.version  = '1.32'
   s.platform = :ios, '5.0'
   s.license  = 'MIT'
   s.summary  = 'An UIAlertView replacement.'
   s.homepage = 'https://github.com/qiaoxueshi/SIAlertView'
   s.author   = { 'Sumi Interactive' => 'developer@sumi-sumi.com' }
   s.source   = { :git => 'https://github.com/qiaoxueshi/SIAlertView.git',
-                 :tag => 'Joey1.31' }
+                 :tag => '1.32' }
 
   s.description = 'An UIAlertView replacement with block syntax and fancy transition styles.'
 

--- a/SIAlertView/SIAlertView.h
+++ b/SIAlertView/SIAlertView.h
@@ -69,6 +69,8 @@ typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
 @property (nonatomic, strong) UIColor *destructiveButtonColor NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
 @property (nonatomic, assign) CGFloat cornerRadius NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR; // default is 2.0
 @property (nonatomic, assign) CGFloat shadowRadius NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR; // default is 8.0
+@property (nonatomic, assign) NSInteger messageMinLineCount NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR; // default is 3
+@property (nonatomic, assign) NSInteger messageMaxLineCount NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR; // default is 5
 
 - (void)setDefaultButtonImage:(UIImage *)defaultButtonImage forState:(UIControlState)state NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
 - (void)setCancelButtonImage:(UIImage *)cancelButtonImage forState:(UIControlState)state NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;

--- a/SIAlertView/SIAlertView.h
+++ b/SIAlertView/SIAlertView.h
@@ -45,6 +45,7 @@ typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) NSString *message;
 @property (nonatomic, assign) NSTextAlignment messageAlignment;
+@property (nonatomic, assign) CGFloat containerWidth; //default is 300.f
 
 @property (nonatomic, assign) SIAlertViewTransitionStyle transitionStyle; // default is SIAlertViewTransitionStyleSlideFromBottom
 @property (nonatomic, assign) SIAlertViewBackgroundStyle backgroundStyle; // default is SIAlertViewButtonTypeGradient

--- a/SIAlertView/SIAlertView.h
+++ b/SIAlertView/SIAlertView.h
@@ -44,6 +44,7 @@ typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
 
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) NSString *message;
+@property (nonatomic, assign) NSTextAlignment messageAlignment;
 
 @property (nonatomic, assign) SIAlertViewTransitionStyle transitionStyle; // default is SIAlertViewTransitionStyleSlideFromBottom
 @property (nonatomic, assign) SIAlertViewBackgroundStyle backgroundStyle; // default is SIAlertViewButtonTypeGradient
@@ -71,6 +72,7 @@ typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
 @property (nonatomic, assign) CGFloat shadowRadius NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR; // default is 8.0
 @property (nonatomic, assign) NSInteger messageMinLineCount NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR; // default is 3
 @property (nonatomic, assign) NSInteger messageMaxLineCount NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR; // default is 5
+
 
 - (void)setDefaultButtonImage:(UIImage *)defaultButtonImage forState:(UIControlState)state NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
 - (void)setCancelButtonImage:(UIImage *)cancelButtonImage forState:(UIControlState)state NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -23,7 +23,6 @@ NSString *const SIAlertViewDidDismissNotification = @"SIAlertViewDidDismissNotif
 #define CONTENT_PADDING_TOP 12
 #define CONTENT_PADDING_BOTTOM 10
 #define BUTTON_HEIGHT 44
-#define CONTAINER_WIDTH 300
 
 const UIWindowLevel UIWindowLevelSIAlert = 1996.0;  // don't overlap system's alert
 const UIWindowLevel UIWindowLevelSIAlertBackground = 1985.0; // below the alert window
@@ -262,6 +261,7 @@ static SIAlertView *__si_alert_current_view;
         _message = message;
         
         _messageAlignment = NSTextAlignmentCenter;
+        _containerWidth = 300.f;
         _enabledParallaxEffect = YES;
 		self.items = [[NSMutableArray alloc] init];
 	}
@@ -719,10 +719,10 @@ static SIAlertView *__si_alert_current_view;
 #endif
     
     CGFloat height = [self preferredHeight];
-    CGFloat left = (self.bounds.size.width - CONTAINER_WIDTH) * 0.5;
+    CGFloat left = (self.bounds.size.width - self.containerWidth) * 0.5;
     CGFloat top = (self.bounds.size.height - height) * 0.5;
     self.containerView.transform = CGAffineTransformIdentity;
-    self.containerView.frame = CGRectMake(left, top, CONTAINER_WIDTH, height);
+    self.containerView.frame = CGRectMake(left, top, self.containerWidth, height);
     self.containerView.layer.shadowPath = [UIBezierPath bezierPathWithRoundedRect:self.containerView.bounds cornerRadius:self.containerView.layer.cornerRadius].CGPath;
     
     CGFloat y = CONTENT_PADDING_TOP;
@@ -808,7 +808,7 @@ static SIAlertView *__si_alert_current_view;
                        self.titleLabel.minimumFontSize
 #endif
                                 actualFontSize:nil
-                                      forWidth:CONTAINER_WIDTH - CONTENT_PADDING_LEFT * 2
+                                      forWidth:self.containerWidth - CONTENT_PADDING_LEFT * 2
                                  lineBreakMode:self.titleLabel.lineBreakMode];
         return size.height;
     }
@@ -821,7 +821,7 @@ static SIAlertView *__si_alert_current_view;
     if (self.messageLabel) {
         CGFloat maxHeight = self.messageMaxLineCount * self.messageLabel.font.lineHeight;
         CGSize size = [self.message sizeWithFont:self.messageLabel.font
-                               constrainedToSize:CGSizeMake(CONTAINER_WIDTH - CONTENT_PADDING_LEFT * 2, maxHeight)
+                               constrainedToSize:CGSizeMake(self.containerWidth - CONTENT_PADDING_LEFT * 2, maxHeight)
                                    lineBreakMode:self.messageLabel.lineBreakMode];
         return MAX(minHeight, size.height);
     }

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -17,8 +17,6 @@ NSString *const SIAlertViewDidDismissNotification = @"SIAlertViewDidDismissNotif
 
 #define DEBUG_LAYOUT 0
 
-#define MESSAGE_MIN_LINE_COUNT 3
-#define MESSAGE_MAX_LINE_COUNT 5
 #define GAP 10
 #define CANCEL_BUTTON_PADDING_TOP 5
 #define CONTENT_PADDING_LEFT 10
@@ -247,6 +245,8 @@ static SIAlertView *__si_alert_current_view;
     appearance.destructiveButtonColor = [UIColor whiteColor];
     appearance.cornerRadius = 2;
     appearance.shadowRadius = 8;
+    appearance.messageMinLineCount = 3;
+    appearance.messageMaxLineCount = 5;
 }
 
 - (id)init
@@ -815,9 +815,9 @@ static SIAlertView *__si_alert_current_view;
 
 - (CGFloat)heightForMessageLabel
 {
-    CGFloat minHeight = MESSAGE_MIN_LINE_COUNT * self.messageLabel.font.lineHeight;
+    CGFloat minHeight = self.messageMinLineCount * self.messageLabel.font.lineHeight;
     if (self.messageLabel) {
-        CGFloat maxHeight = MESSAGE_MAX_LINE_COUNT * self.messageLabel.font.lineHeight;
+        CGFloat maxHeight = self.messageMaxLineCount * self.messageLabel.font.lineHeight;
         CGSize size = [self.message sizeWithFont:self.messageLabel.font
                                constrainedToSize:CGSizeMake(CONTAINER_WIDTH - CONTENT_PADDING_LEFT * 2, maxHeight)
                                    lineBreakMode:self.messageLabel.lineBreakMode];
@@ -897,7 +897,7 @@ static SIAlertView *__si_alert_current_view;
             self.messageLabel.backgroundColor = [UIColor clearColor];
             self.messageLabel.font = self.messageFont;
             self.messageLabel.textColor = self.messageColor;
-            self.messageLabel.numberOfLines = MESSAGE_MAX_LINE_COUNT;
+            self.messageLabel.numberOfLines = self.messageMaxLineCount;
             [self.containerView addSubview:self.messageLabel];
 #if DEBUG_LAYOUT
             self.messageLabel.backgroundColor = [UIColor redColor];
@@ -1133,6 +1133,14 @@ static SIAlertView *__si_alert_current_view;
             [button setTitleColor:[color colorWithAlphaComponent:0.8] forState:UIControlStateHighlighted];
         }
     }
+}
+
+- (void)setMessageMaxLineCount:(NSInteger)messageMaxLineCount {
+    _messageMaxLineCount = messageMaxLineCount;
+}
+
+- (void)setMessageMinLineCount:(NSInteger)messageMinLineCount {
+    _messageMinLineCount = messageMinLineCount;
 }
 
 # pragma mark -

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -260,6 +260,8 @@ static SIAlertView *__si_alert_current_view;
 	if (self) {
 		_title = title;
         _message = message;
+        
+        _messageAlignment = NSTextAlignmentCenter;
         _enabledParallaxEffect = YES;
 		self.items = [[NSMutableArray alloc] init];
 	}
@@ -893,7 +895,7 @@ static SIAlertView *__si_alert_current_view;
     if (self.message) {
         if (!self.messageLabel) {
             self.messageLabel = [[UILabel alloc] initWithFrame:self.bounds];
-            self.messageLabel.textAlignment = NSTextAlignmentCenter;
+            self.messageLabel.textAlignment = self.messageAlignment;
             self.messageLabel.backgroundColor = [UIColor clearColor];
             self.messageLabel.font = self.messageFont;
             self.messageLabel.textColor = self.messageColor;


### PR DESCRIPTION
The origin macro `MESSAGE_MIN_LINE_COUNT` and `MESSAGE_MAX_LINE_COUNT` is not very convenient to change without changing the code, So I add two appearance property `messageMinLineCount` and `messageMaxLineCount` to improve this.
