### PR TITLE
save oldTintAdjustmentMode only when new alert view is displayed...

### DIFF
--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -358,14 +358,6 @@ static SIAlertView *__si_alert_current_view;
         return;
     }
     
-    self.oldKeyWindow = [[UIApplication sharedApplication] keyWindow];
-#ifdef __IPHONE_7_0
-    if ([self.oldKeyWindow respondsToSelector:@selector(setTintAdjustmentMode:)]) { // for iOS 7
-        self.oldTintAdjustmentMode = self.oldKeyWindow.tintAdjustmentMode;
-        self.oldKeyWindow.tintAdjustmentMode = UIViewTintAdjustmentModeDimmed;
-    }
-#endif
-
     if (![[SIAlertView sharedQueue] containsObject:self]) {
         [[SIAlertView sharedQueue] addObject:self];
     }
@@ -380,6 +372,14 @@ static SIAlertView *__si_alert_current_view;
         return;
     }
     
+    self.oldKeyWindow = [[UIApplication sharedApplication] keyWindow];
+#ifdef __IPHONE_7_0
+    if ([self.oldKeyWindow respondsToSelector:@selector(setTintAdjustmentMode:)]) { // for iOS 7
+        self.oldTintAdjustmentMode = self.oldKeyWindow.tintAdjustmentMode;
+        self.oldKeyWindow.tintAdjustmentMode = UIViewTintAdjustmentModeDimmed;
+    }
+#endif
+
     if (self.willShowHandler) {
         self.willShowHandler(self);
     }


### PR DESCRIPTION
if an alert view is displayed, and display another alert view, this
will make main window has UIViewTintAdjustmentModeDimmed, and never
come back to normal again, and Buttons/Tabbar/Toolbar will lose
tintColor
