### PR TITLE
Add custom view support

### DIFF
--- a/SIAlertView/SIAlertView.h
+++ b/SIAlertView/SIAlertView.h
@@ -78,6 +78,8 @@ typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
 
 
 - (id)initWithTitle:(NSString *)title message:(NSString *)message;
+- (id)initWithTitle:(NSString *)title andCustomView:(UIView *)customView;
+
 - (id)initWithTitle:(NSString *)title message:(NSString *)message cancelButton:(NSString *)canelButton handler:(SIAlertViewHandler)handler;
 - (id)initWithAttributedTitle:(NSAttributedString *)attributedTitle attributedMessage:(NSAttributedString *)attributedMessage;
 - (void)addButtonWithTitle:(NSString *)title type:(SIAlertViewButtonType)type handler:(SIAlertViewHandler)handler;

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -947,8 +947,8 @@ static SIAlertView *__si_alert_current_view;
     self.titleLabel = nil;
     self.messageLabel = nil;
     
-    [self.customView removeFromSuperview];
-    self.customView = nil;
+    //[self.customView removeFromSuperview];
+    //self.customView = nil;
     
     [self.buttons removeAllObjects];
     [self.alertWindow removeFromSuperview];

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -256,6 +256,21 @@ static SIAlertView *__si_alert_current_view;
 	return self;
 }
 
+#pragma mark - Notification handle methods
+
+- (void)keyboardDidShow:(NSNotification *)notif{
+    NSDictionary* info = [notif userInfo];
+    NSValue* aValue = [info objectForKey:UIKeyboardFrameEndUserInfoKey];
+    CGSize keyboardSize = [aValue CGRectValue].size;
+    CGRect frame = self.containerView.frame;
+    CGFloat y = (self.frame.size.height-keyboardSize.height- self.containerView.frame.size.height)/2;
+    frame.origin.y = MAX(y,0);
+    [UIView animateWithDuration:0.25 animations:^{
+        self.containerView.frame = frame;
+    }];
+    
+}
+
 #pragma mark - Class methods
 
 + (NSMutableArray *)sharedQueue
@@ -915,6 +930,7 @@ static SIAlertView *__si_alert_current_view;
 
 - (void)setup
 {
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidShow:) name:UIKeyboardDidShowNotification object:nil];
     [self setupViewHierarchy];
     [self updateTitleLabel];
     [self setupCustomView];
@@ -925,6 +941,7 @@ static SIAlertView *__si_alert_current_view;
 
 - (void)teardown
 {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self.containerView removeFromSuperview];
     self.containerView = nil;
     self.titleLabel = nil;

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -40,6 +40,7 @@ static SIAlertView *__si_alert_current_view;
 @property (nonatomic, assign, getter = isVisible) BOOL visible;
 
 @property (nonatomic, strong) UILabel *titleLabel;
+@property (nonatomic, strong) UIView *customView;
 @property (nonatomic, strong) UILabel *messageLabel;
 @property (nonatomic, strong) UIView *containerView;
 @property (nonatomic, strong) UIView *wrapperView;
@@ -215,6 +216,16 @@ static SIAlertView *__si_alert_current_view;
 		self.items = [NSMutableArray array];
 	}
 	return self;
+}
+
+- (id)initWithTitle:(NSString *)title andCustomView:(UIView *)customView{
+    self = [super init];
+    if (self) {
+        _title = title;
+        _customView = customView;
+        self.items = [[NSMutableArray alloc] init];
+    }
+    return self;
 }
 
 - (id)initWithTitle:(NSString *)title message:(NSString *)message cancelButton:(NSString *)canelButton handler:(SIAlertViewHandler)handler
@@ -807,6 +818,15 @@ static SIAlertView *__si_alert_current_view;
         self.titleLabel.frame = CGRectMake(CONTENT_PADDING_LEFT, y, CONTAINER_WIDTH - CONTENT_PADDING_LEFT * 2, height);
         y += height;
 	}
+    if (self.customView) {
+        if (y > CONTENT_PADDING_TOP) {
+            y += GAP;
+        }
+        CGFloat height = self.customView.frame.size.height;
+        
+        self.customView.frame = CGRectMake(CONTENT_PADDING_LEFT, y, CONTAINER_WIDTH - CONTENT_PADDING_LEFT * 2, height);
+        y += height + GAP;
+    }
     if (self.messageLabel) {
         if (y > CONTENT_PADDING_TOP) {
             y += GAP;
@@ -897,6 +917,7 @@ static SIAlertView *__si_alert_current_view;
 {
     [self setupViewHierarchy];
     [self updateTitleLabel];
+    [self setupCustomView];
     [self updateMessageLabel];
     [self setupButtons];
     [self setupLineLayer];
@@ -908,6 +929,10 @@ static SIAlertView *__si_alert_current_view;
     self.containerView = nil;
     self.titleLabel = nil;
     self.messageLabel = nil;
+    
+    [self.customView removeFromSuperview];
+    self.customView = nil;
+    
     [self.buttons removeAllObjects];
     [self.alertWindow removeFromSuperview];
     self.alertWindow = nil;
@@ -928,6 +953,7 @@ static SIAlertView *__si_alert_current_view;
     self.wrapperView.backgroundColor = self.viewBackgroundColor;
     self.wrapperView.layer.cornerRadius = self.cornerRadius;
     self.wrapperView.clipsToBounds = YES;
+    //self.wrapperView.backgroundColor = [UIColor redColor];
     [self.containerView addSubview:self.wrapperView];
     
     self.contentContainerView = [[UIScrollView alloc] initWithFrame:self.bounds];
@@ -966,9 +992,24 @@ static SIAlertView *__si_alert_current_view;
 	}
     [self invalidateLayout];
 }
+- (void)setupCustomView{
+    if (self.customView) {
+        
+        //self.customView.frame = self.bounds;
+        
+        [self.contentContainerView addSubview:self.customView];
+#if DEBUG_LAYOUT
+        self.customView.backgroundColor = [UIColor redColor];
+#endif
+    }
+    [self invalidateLayout];
+}
 
 - (void)updateMessageLabel
 {
+    if (self.customView) {
+        return;
+    }
     if (self.message) {
         if (!self.messageLabel) {
             self.messageLabel = [[UILabel alloc] initWithFrame:self.bounds];

--- a/SIAlertViewExample/SIAlertViewExample.xcodeproj/project.xcworkspace/xcshareddata/SIAlertViewExample.xccheckout
+++ b/SIAlertViewExample/SIAlertViewExample.xcodeproj/project.xcworkspace/xcshareddata/SIAlertViewExample.xccheckout
@@ -10,29 +10,29 @@
 	<string>SIAlertViewExample</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>1EE19127-7F15-4095-A45D-7D481FB08953</key>
+		<key>E2E339EC05FF99AF5ECAE62EDBC78398DA1111C6</key>
 		<string>https://github.com/Sumi-Interactive/SIAlertView.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>SIAlertViewExample/SIAlertViewExample.xcodeproj/project.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>1EE19127-7F15-4095-A45D-7D481FB08953</key>
+		<key>E2E339EC05FF99AF5ECAE62EDBC78398DA1111C6</key>
 		<string>../../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
 	<string>https://github.com/Sumi-Interactive/SIAlertView.git</string>
 	<key>IDESourceControlProjectVersion</key>
-	<integer>110</integer>
+	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>1EE19127-7F15-4095-A45D-7D481FB08953</string>
+	<string>E2E339EC05FF99AF5ECAE62EDBC78398DA1111C6</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>1EE19127-7F15-4095-A45D-7D481FB08953</string>
+			<string>E2E339EC05FF99AF5ECAE62EDBC78398DA1111C6</string>
 			<key>IDESourceControlWCCName</key>
 			<string>SIAlertView</string>
 		</dict>

--- a/SIAlertViewExample/SIAlertViewExample/ViewController.m
+++ b/SIAlertViewExample/SIAlertViewExample/ViewController.m
@@ -246,9 +246,20 @@ id observer1,observer2,observer3,observer4;
 
 - (IBAction)alert4:(id)sender
 {
-    [self alert1:nil];
-    [self alert2:nil];
-    [self alert3:nil];
+    UITextField *field = [[UITextField alloc] initWithFrame:CGRectMake(0, 0, 200, 44)];
+    [field setFont:[UIFont systemFontOfSize:40.0]];
+    [field setBorderStyle:UITextBorderStyleRoundedRect];
+    //field.backgroundColor = [UIColor redColor];
+    SIAlertView *alertView = [[SIAlertView alloc] initWithTitle:@"Custom View" andCustomView:field];
+    [alertView addButtonWithTitle:@"Cancel"
+                             font:nil
+                            color:[UIColor orangeColor]
+                             type:SIAlertViewButtonTypeCancel
+                          handler:^(SIAlertView *alertView) {
+                              NSLog(@"Cancel Clicked");
+                          }];
+
+    [alertView show];
 }
 
 - (NSUInteger)supportedInterfaceOrientations


### PR DESCRIPTION
Add custom view support , 
how to use:
`- (id)initWithTitle:(NSString *)title andCustomView:(UIView *)customView;`

example:

```
  UITextField *field = [[UITextField alloc] initWithFrame:CGRectMake(0, 0, 200, 44)];
    [field setFont:[UIFont systemFontOfSize:40.0]];
    [field setBorderStyle:UITextBorderStyleRoundedRect];
    //field.backgroundColor = [UIColor redColor];
    SIAlertView *alertView = [[SIAlertView alloc] initWithTitle:@"Custom View" andCustomView:field];
    [alertView addButtonWithTitle:@"Cancel"
                             font:nil
                            color:[UIColor orangeColor]
                             type:SIAlertViewButtonTypeCancel
                          handler:^(SIAlertView *alertView) {
                              NSLog(@"Cancel Clicked");
                          }];

    [alertView show];
}
```
