### PR TITLE
Fix crash in ios 6

### DIFF
--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -301,9 +301,21 @@ static SIAlertView *__si_alert_current_view;
     if (!__si_alert_background_window) {
         
         CGRect frame = [[UIScreen mainScreen] bounds];
-        if([[UIScreen mainScreen] respondsToSelector:@selector(fixedCoordinateSpace)])
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < 80000
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
+        
+        if(![[UIScreen mainScreen] respondsToSelector:@selector(fixedCoordinateSpace)])
         {
+#endif
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
+        }
+        else
+#endif
+#endif
+        {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
             frame = [[[UIScreen mainScreen] fixedCoordinateSpace] convertRect:frame fromCoordinateSpace:[[UIScreen mainScreen] coordinateSpace]];
+#endif
         }
         
         __si_alert_background_window = [[SIAlertBackgroundWindow alloc] initWithFrame:frame
@@ -805,7 +817,30 @@ static SIAlertView *__si_alert_current_view;
 - (CGFloat)heightForTitleLabel
 {
     if (self.titleLabel) {
-        #ifdef __IPHONE_7_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < 70000
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+        if (![self.titleLabel.text respondsToSelector:@selector(boundingRectWithSize:options:attributes:context:)]) {
+#endif
+            CGSize size = [self.title sizeWithFont:self.titleLabel.font
+                                       minFontSize:
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_6_0
+                           self.titleLabel.font.pointSize * self.titleLabel.minimumScaleFactor
+#else
+                           self.titleLabel.minimumFontSize
+#endif
+                                    actualFontSize:nil
+                                          forWidth:CONTAINER_WIDTH - CONTENT_PADDING_LEFT * 2
+                                     lineBreakMode:self.titleLabel.lineBreakMode];
+            return size.height;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+            
+        }
+        else
+#endif
+#endif
+        {
+            
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
             NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
             paragraphStyle.lineBreakMode = self.titleLabel.lineBreakMode;
             
@@ -819,19 +854,9 @@ static SIAlertView *__si_alert_current_view;
                                                           attributes:attributes
                                                              context:nil];
             return ceil(rect.size.height);
-        #else
-            CGSize size = [self.title sizeWithFont:self.titleLabel.font
-                                       minFontSize:
-                                                    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_6_0
-                                                       self.titleLabel.font.pointSize * self.titleLabel.minimumScaleFactor
-                                                    #else
-                                                       self.titleLabel.minimumFontSize
-                                                    #endif
-                                    actualFontSize:nil
-                                          forWidth:CONTAINER_WIDTH - CONTENT_PADDING_LEFT * 2
-                                     lineBreakMode:self.titleLabel.lineBreakMode];
-            return size.height;
-        #endif
+#endif
+ 
+        }
     }
     
     return 0;
@@ -843,7 +868,26 @@ static SIAlertView *__si_alert_current_view;
     if (self.messageLabel) {
         CGFloat maxHeight = MESSAGE_MAX_LINE_COUNT * self.messageLabel.font.lineHeight;
         
-        #ifdef __IPHONE_7_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < 70000
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+        if (![self.titleLabel.text respondsToSelector:@selector(boundingRectWithSize:options:attributes:context:)]) {
+#endif
+            CGSize size = [self.message sizeWithFont:self.messageLabel.font
+                                   constrainedToSize:CGSizeMake(CONTAINER_WIDTH - CONTENT_PADDING_LEFT * 2, maxHeight)
+                                       lineBreakMode:self.messageLabel.lineBreakMode];
+            
+            return MAX(minHeight, size.height);
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+
+        }
+        else
+            
+#endif
+#endif
+
+        {
+            
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
             NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
             paragraphStyle.lineBreakMode = self.messageLabel.lineBreakMode;
             
@@ -858,13 +902,9 @@ static SIAlertView *__si_alert_current_view;
                                                              context:nil];
             
             return MAX(minHeight, ceil(rect.size.height));
-        #else
-            CGSize size = [self.message sizeWithFont:self.messageLabel.font
-                                   constrainedToSize:CGSizeMake(CONTAINER_WIDTH - CONTENT_PADDING_LEFT * 2, maxHeight)
-                                       lineBreakMode:self.messageLabel.lineBreakMode];
+#endif
             
-            return MAX(minHeight, size.height);
-        #endif
+        }
     }
     
     return minHeight;


### PR DESCRIPTION
When I use SIAlertView in iOS6, I found app crashed because of unrecognized selector `sizeWithFont:constrainedToSize:lineBreakMode`. I just do something like this https://gist.github.com/nicklockwood/d63c69ba2f40a33d7aa4
