### PR TITLE
fixed the bug occurred in iOS9, when i use after SIAlertView, the keywindow = nil, lead to something  Breaks scroll to top left, ex use the SVProgressHUD

### DIFF
--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -883,6 +883,19 @@ static SIAlertView *__si_alert_current_view;
 
 - (void)teardown
 {
+    NSEnumerator *frontToBackWindows = [UIApplication.sharedApplication.windows reverseObjectEnumerator];
+    
+    for (UIWindow *window in frontToBackWindows){
+        BOOL windowOnMainScreen = window.screen == UIScreen.mainScreen;
+        BOOL windowIsVisible = !window.hidden && window.alpha > 0;
+        BOOL windowLevelNormal = window.windowLevel == UIWindowLevelNormal;
+        
+        if (windowOnMainScreen && windowIsVisible && windowLevelNormal) {
+            [window makeKeyAndVisible];
+            break;
+        }
+    }
+    
     [self.containerView removeFromSuperview];
     self.containerView = nil;
     self.titleLabel = nil;

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -901,6 +901,7 @@ static SIAlertView *__si_alert_current_view;
             break;
         }
     }
+    
     [self.alertWindow removeFromSuperview];
     self.alertWindow = nil;
     self.layoutDirty = NO;

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -883,6 +883,12 @@ static SIAlertView *__si_alert_current_view;
 
 - (void)teardown
 {
+    [self.containerView removeFromSuperview];
+    self.containerView = nil;
+    self.titleLabel = nil;
+    self.messageLabel = nil;
+    [self.buttons removeAllObjects];
+    
     NSEnumerator *frontToBackWindows = [UIApplication.sharedApplication.windows reverseObjectEnumerator];
     
     for (UIWindow *window in frontToBackWindows){
@@ -895,12 +901,6 @@ static SIAlertView *__si_alert_current_view;
             break;
         }
     }
-    
-    [self.containerView removeFromSuperview];
-    self.containerView = nil;
-    self.titleLabel = nil;
-    self.messageLabel = nil;
-    [self.buttons removeAllObjects];
     [self.alertWindow removeFromSuperview];
     self.alertWindow = nil;
     self.layoutDirty = NO;


### PR DESCRIPTION
fixed the bug occurred in iOS9, when i use after SIAlertView, the keywindow = nil, lead to something  Breaks scroll to top left, ex use the SVProgressHUD

possibly fixed the bug #95 
Breaks scroll to top.
