### PR TITLE
fix 2 bugs

### DIFF
--- a/SIAlertView/SIAlertView.h
+++ b/SIAlertView/SIAlertView.h
@@ -60,7 +60,7 @@ typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
 @property (nonatomic, copy) SIAlertViewHandler didDismissHandler;
 
 @property (nonatomic, readonly, getter = isVisible) BOOL visible;
-
+@property (nonatomic, assign) BOOL enableAutoRotation;//default NO, doesn't support autorotation or landscape.
 @property (nonatomic, assign) BOOL parallaxEffectEnabled;
 
 // theme
@@ -80,7 +80,6 @@ typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
 @property (nonatomic, strong) UIColor *defaultButtonBackgroundColor NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIColor *cancelButtonBackgroundColor NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIColor *destructiveButtonBackgroundColor NS_AVAILABLE_IOS(5_0) UI_APPEARANCE_SELECTOR;
-
 
 - (id)initWithTitle:(NSString *)title message:(NSString *)message;
 - (id)initWithTitle:(NSString *)title message:(NSString *)message cancelButton:(NSString *)canelButton handler:(SIAlertViewHandler)handler;

--- a/SIAlertView/SIAlertView.h
+++ b/SIAlertView/SIAlertView.h
@@ -40,10 +40,12 @@ typedef NS_ENUM(NSInteger, SIAlertViewTransitionStyle) {
 @class SIAlertView;
 typedef void(^SIAlertViewHandler)(SIAlertView *alertView);
 
-@interface SIAlertView : UIView
+@interface SIAlertView : UIView<UITextFieldDelegate>
 
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) NSString *message;
+@property (nonatomic, strong) UITextField *textField;
+@property (nonatomic, copy) void(^textFieldReturnBlock)();
 
 @property (nonatomic, copy) NSAttributedString *attributedTitle;
 @property (nonatomic, copy) NSAttributedString *attributedMessage;

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -293,6 +293,9 @@ static SIAlertView *__si_alert_current_view;
 
 + (void)showBackground
 {
+    if (__si_alert_background_window != nil){
+        [SIAlertView hideBackgroundAnimated:NO];
+    }
     if (!__si_alert_background_window) {
         __si_alert_background_window = [[SIAlertBackgroundWindow alloc] initWithFrame:[UIScreen mainScreen].bounds
                                                                              andStyle:[SIAlertView currentAlertView].backgroundStyle];

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -301,13 +301,11 @@ static SIAlertView *__si_alert_current_view;
 + (void)hideBackgroundAnimated:(BOOL)animated
 {
     void (^completion)(void) = ^{
-        [__si_alert_background_window removeFromSuperview];
-        __si_alert_background_window = nil;
-        
         UIWindow *mainWindow = [UIApplication sharedApplication].windows[0];
         mainWindow.tintAdjustmentMode = UIViewTintAdjustmentModeNormal;
         [mainWindow makeKeyWindow];
-        mainWindow.hidden = NO;
+        __si_alert_background_window.hidden = YES;
+        __si_alert_background_window = nil;
     };
     
     if (!animated) {
@@ -548,8 +546,6 @@ static SIAlertView *__si_alert_current_view;
     }
     
     void (^dismissComplete)(void) = ^{
-        self.visible = NO;
-        
         [self teardown];
         
         [SIAlertView setCurrentAlertView:nil];
@@ -918,7 +914,7 @@ static SIAlertView *__si_alert_current_view;
     self.titleLabel = nil;
     self.messageLabel = nil;
     [self.buttons removeAllObjects];
-    [self.alertWindow removeFromSuperview];
+    self.alertWindow.hidden = YES;
     self.alertWindow = nil;
     self.layoutDirty = NO;
 }

--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -166,6 +166,14 @@ static SIAlertView *__si_alert_current_view;
     [self.alertView setup];
 }
 
+-(BOOL)shouldAutorotate{
+    return self.alertView.enableAutoRotation;
+}
+
+-(UIInterfaceOrientationMask)supportedInterfaceOrientations{
+    return self.alertView.enableAutoRotation ? [super supportedInterfaceOrientations] : UIInterfaceOrientationMaskPortrait;
+}
+
 - (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
 {
     [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
@@ -182,6 +190,7 @@ static SIAlertView *__si_alert_current_view;
 @synthesize textField;
 @synthesize textFieldReturnBlock;
 @synthesize attributedTitle = _attributedTitle, attributedMessage = _attributedMessage;
+@synthesize enableAutoRotation;
 
 + (void)initialize
 {
@@ -1021,7 +1030,7 @@ static SIAlertView *__si_alert_current_view;
     
     CGRect containerViewFrame = self.containerView.frame;
     containerViewFrame.origin.y = self.frame.size.height - kbSize.height - containerViewFrame.size.height - 6;
-    if (containerViewFrame.origin.y > self.containerView.frame.origin.y) {
+    if (containerViewFrame.origin.y < self.containerView.frame.origin.y) {
         self.containerView.frame = containerViewFrame;
     }
 }


### PR DESCRIPTION
fix 2 bugs:
1. alertWindow still show after alertView dismissed. To duplicate this
bug, just set alertView.backgroundColor = [UIColor redColor]; before
show it.
2. tap Screen after alertView dismissed, iOS log error message:
unexpected nil window in _UIApplicationHandleEventFromQueueEvent,
_windowServerHitTestWindow: (null)
Solution:
1. remove invokes of removeFromSuperview for UIWindow instance.
2. make __si_alert_background_window and alertWindow hidden when
dismiss alertView.
