### PR TITLE
Fix: Force background redraw after rotation

### DIFF
--- a/SIAlertView/SIAlertView.m
+++ b/SIAlertView/SIAlertView.m
@@ -126,6 +126,11 @@ static SIAlertView *__si_alert_current_view;
     }
 }
 
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    [self setNeedsDisplay];
+}
+
 @end
 
 #pragma mark - SIAlertItem


### PR DESCRIPTION
Fix: SIAlertBackgroundWindow is stretched in gradient style instead of redrawn after device rotation.
